### PR TITLE
Changes in the return of of synthesize functions

### DIFF
--- a/MilneEddington.py
+++ b/MilneEddington.py
@@ -135,7 +135,7 @@ class MilneEddington:
 
             
             
-        return self.Me.synthesize(model, mu=mu)
+        return self.Me.synthesize(model1, mu=mu)
 
 
     # *************************************************************************************************
@@ -186,7 +186,7 @@ class MilneEddington:
 
             
             
-        return self.Me.synthesize_RF(model, mu=mu)
+        return self.Me.synthesize_RF(model1, mu=mu)
 
     # *************************************************************************************************
       


### PR DESCRIPTION
The funtions "synthesize" and "synthesize_rf" were returning the same model variable without perfom any changes on that. I changed do "model1' in the return part. Hope it will fix some errors in the test files.